### PR TITLE
Clean up `build_grid` in remez code

### DIFF
--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -194,23 +194,20 @@ function build_grid(numtaps, bands, desired, weight, grid_density, filter_type::
     # SET UP THE DENSE GRID. THE NUMBER OF POINTS IN THE GRID
     # IS (FILTER LENGTH + 1)*GRID DENSITY/2
     #
-    grid[1] = edge[1]
     delf = lgrid * nfcns
     delf = 0.5 / delf
-    if neg
-        if edge[1] < delf
-            grid[1] = delf
-        end
-    end
     j = 1
     l = 1
-    lband = 1
 
     #
     # CALCULATE THE DESIRED MAGNITUDE RESPONSE AND THE WEIGHT
     # FUNCTION ON THE GRID
     #
-    while true
+    for lband in 1:nbands
+        grid[j] = edge[l]
+        if neg && edge[j] < delf
+            grid[j] = delf
+        end
         fup = edge[l + 1]
         while true
             temp = grid[j]
@@ -229,12 +226,7 @@ function build_grid(numtaps, bands, desired, weight, grid_density, filter_type::
         grid[j-1] = fup
         des[j-1] = eff(fup,fx,lband,filter_type)
         wt[j-1] = wate(fup,fx,wtx,lband,filter_type)
-        lband += 1
         l += 2
-        if lband > nbands
-            break
-        end
-        grid[j] = edge[l]
     end
 
     ngrid = j - 1

--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -204,28 +204,25 @@ function build_grid(numtaps, bands, desired, weight, grid_density, filter_type::
     # FUNCTION ON THE GRID
     #
     for lband in 1:nbands
-        grid[j] = edge[l]
-        if neg && edge[j] < delf
-            grid[j] = delf
+        flow = edge[l]
+        if neg && flow < delf
+            flow = delf
         end
         fup = edge[l + 1]
-        while true
-            temp = grid[j]
-            des[j] = eff(temp,fx,lband,filter_type)
-            wt[j] = wate(temp,fx,wtx,lband,filter_type)
+        for f in (flow:delf:fup)[1:end-1]
+            grid[j] = f
+            des[j] = eff(f,fx,lband,filter_type)
+            wt[j] = wate(f,fx,wtx,lband,filter_type)
             j += 1
             if j > wrksize
                 # too many points, or too dense grid
                 return -1
             end
-            grid[j] = temp + delf
-            if grid[j] > fup
-                break
-            end
         end
-        grid[j-1] = fup
-        des[j-1] = eff(fup,fx,lband,filter_type)
-        wt[j-1] = wate(fup,fx,wtx,lband,filter_type)
+        grid[j] = fup
+        des[j] = eff(fup,fx,lband,filter_type)
+        wt[j] = wate(fup,fx,wtx,lband,filter_type)
+        j += 1
         l += 2
     end
 

--- a/src/Filters/remez_fir.jl
+++ b/src/Filters/remez_fir.jl
@@ -168,10 +168,6 @@ return "grid" and "des" and "wt" arrays
 """
 function build_grid(numtaps, bands, desired, weight, grid_density, filter_type::RemezFilterType)
     # translate from scipy remez argument names
-    L = numtaps
-    M = L ÷ 2    # integer divide (truncated)
-    grid_spacing = 0.5 / (grid_density * M)  # "delf" or "delta f"
-
     lgrid = grid_density
     dimsize = Int( ceil(numtaps/2.0 + 2) )
     wrksize = grid_density * dimsize


### PR DESCRIPTION
In my opinion, the code is more readable this way. Also, it prevents the error condition of `wrksize` begin too small by computing the exact needed array length beforehand.